### PR TITLE
Support for large svg files and option to install without poetry.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .venv_pypy/
 .vscode/
 .env
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This module and supporting routines are experimental.
 
 The module is still in development. You can install it by cloning this repository and using the [poetry install](https://python-poetry.org/docs/cli/#install) command.
 
-Alternatively, you can use pip install -r requirements.txt. This was generated using [poetry export](https://python-poetry.org/docs/cli/#export) without hashes option.
+Alternatively, you can run ./install.sh to install the module into a virtual environment to be activated with
+
+```bash
+source /path/to/remarkable-layers/env/bin/activate
+```
 
 ## Core Dependencies
 
@@ -19,6 +23,8 @@ The core module for reading & writing rm line files only uses core python standa
 The SVG conversion module utilises numpy and lxml.
 
 The example scripts introduce other dependencies.
+
+To run pdf_converter.py you might need to install the [inkscape-applytransform](https://github.com/Klowner/inkscape-applytransforms) extension.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+[ ! -d .env ] && python3 -m venv .env
+source .env/bin/activate
+
+pip3 install --upgrade pip
+pip3 install numpy==1.19.0 wheel
+pip3 install -r venv_requirements.txt
+python3 setup.py develop

--- a/rmlines/svg.py
+++ b/rmlines/svg.py
@@ -83,7 +83,8 @@ def svg_to_rmlines(buffer):
 
     TODO: check above before processing.
     """
-    root = ET.fromstring(buffer.read())
+    p = ET.XMLParser(huge_tree=True)
+    root = ET.fromstring(buffer.read(), parser=p)
 
     ins = RMLines()
     layer = Layer()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+import glob, os
+dir_path = os.path.dirname(os.path.realpath(__file__))
+scripts = [file for file in glob.glob(dir_path + "/*.py")]
+
+setup(
+    name="rmlines",
+    version="0.1",
+    packages=["rmlines"],
+)

--- a/venv_requirements.txt
+++ b/venv_requirements.txt
@@ -1,0 +1,14 @@
+ipython
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.9
+lxml==4.5.1
+pillow==7.1.2
+pyaml==19.4.1
+-e git+https://github.com/flupke/pypotrace.git@76c76be2458eb2b56fcbd3bec79b1b4077e35d9e#egg=pypotrace
+pyyaml==5.3.1
+requests==2.24.0
+-e git+https://github.com/bsdz/rmapy.git@d53983e68021402f6b1dc8d736633a9c53f903b2#egg=rmapy
+-e git+https://github.com/mathandy/svgpathtools.git@f99f9d6bb3519ecdcb7b167f75a09178595cf89c#egg=svgpathtools
+svgwrite==1.4
+urllib3==1.25.9


### PR DESCRIPTION
Thank you very much for this software! I needed to port some Maths notes I had in OneNote to my new rM2 and this worked like a charm!

However, I had to introduce some fixes to make it work, which are included in this pull request:

- Support in lxml ElementTree for larger svg files (adding huge_tree=True to the XMLParser).
- Support for installation without Poetry (this is just me being lazy and not wanting to learn how to use Poetry, but it can't hurt).
- Compatibility issue with subprocess (capture_output is a relatively new option, I replaced it with stdout=Pipe, stderr=PIPE).
- To make pdf_converter.py run I had to install an inkscape extension. I have added one line in the README in dependencies.

Would you mind giving it a look and possibly merge these? Thanks!